### PR TITLE
feat: scroll-reveal animations + prefers-reduced-motion polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ scratch/
 test-results/
 playwright-report/
 .playwright-mcp/
+# worktrees
+.worktrees/

--- a/src/components/navigation/Navigation.astro
+++ b/src/components/navigation/Navigation.astro
@@ -247,4 +247,10 @@ const sectionEntries = Object.entries(sections);
       padding: 0.5rem 1rem;
     }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-menu {
+      transition: none;
+    }
+  }
 </style>

--- a/src/components/sections/interests/ConcertsTimeline.astro
+++ b/src/components/sections/interests/ConcertsTimeline.astro
@@ -125,9 +125,12 @@ const { concerts } = Astro.props;
           el.classList.remove("visible");
         });
       }
-      document
-        .querySelector("#interests")
-        ?.scrollIntoView({ behavior: "smooth" });
+      const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
+      document.querySelector("#interests")?.scrollIntoView({
+        behavior: prefersReducedMotion ? "instant" : "smooth",
+      });
     });
   }
   initConcertsToggle();

--- a/src/layouts/Section.astro
+++ b/src/layouts/Section.astro
@@ -43,6 +43,10 @@ const { id, title } = Astro.props;
   }
 </style>
 
+<script is:inline>
+  document.documentElement.classList.add("js-enabled");
+</script>
+
 <script>
   const sections = document.querySelectorAll<HTMLElement>("section[id]");
 

--- a/src/layouts/Section.astro
+++ b/src/layouts/Section.astro
@@ -43,28 +43,6 @@ const { id, title } = Astro.props;
   }
 </style>
 
-<script is:inline>
-  document.documentElement.classList.add("js-enabled");
-</script>
-
-<script>
-  const sections = document.querySelectorAll<HTMLElement>("section[id]");
-
-  const revealObserver = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add("revealed");
-          revealObserver.unobserve(entry.target);
-        }
-      });
-    },
-    { threshold: 0.1 },
-  );
-
-  sections.forEach((section) => revealObserver.observe(section));
-</script>
-
 <section id={id}>
   <div class="section-inner">
     {title && <h2>{title}</h2>}

--- a/src/layouts/Section.astro
+++ b/src/layouts/Section.astro
@@ -32,6 +32,24 @@ const { id, title } = Astro.props;
     margin-bottom: auto;
   }
 
+  @supports (animation-timeline: view()) {
+    .section-inner {
+      animation:
+        section-enter auto ease both,
+        section-exit auto ease both;
+      animation-timeline: view(), view();
+      animation-range:
+        cover 0px cover 50px,
+        cover calc(100% - 50px) cover 100%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .section-inner {
+      animation: none;
+    }
+  }
+
   h2 {
     margin-bottom: 1.5rem;
   }

--- a/src/layouts/Section.astro
+++ b/src/layouts/Section.astro
@@ -34,13 +34,14 @@ const { id, title } = Astro.props;
 
   @supports (animation-timeline: view()) {
     .section-inner {
+      opacity: 0;
       animation:
-        section-enter auto ease both,
-        section-exit auto ease both;
+        section-enter auto ease forwards,
+        section-exit auto ease forwards;
       animation-timeline: view(), view();
       animation-range:
-        cover 0px cover 50px,
-        cover calc(100% - 50px) cover 100%;
+        cover 0px cover 100px,
+        cover calc(100% - 100px) cover 100%;
     }
   }
 

--- a/src/layouts/Section.astro
+++ b/src/layouts/Section.astro
@@ -32,25 +32,6 @@ const { id, title } = Astro.props;
     margin-bottom: auto;
   }
 
-  @supports (animation-timeline: view()) {
-    .section-inner {
-      opacity: 0;
-      animation:
-        section-enter auto ease forwards,
-        section-exit auto ease forwards;
-      animation-timeline: view(), view();
-      animation-range:
-        cover 0px cover 100px,
-        cover calc(100% - 100px) cover 100%;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .section-inner {
-      animation: none;
-    }
-  }
-
   h2 {
     margin-bottom: 1.5rem;
   }

--- a/src/layouts/Section.astro
+++ b/src/layouts/Section.astro
@@ -43,6 +43,24 @@ const { id, title } = Astro.props;
   }
 </style>
 
+<script>
+  const sections = document.querySelectorAll<HTMLElement>("section[id]");
+
+  const revealObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("revealed");
+          revealObserver.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1 },
+  );
+
+  sections.forEach((section) => revealObserver.observe(section));
+</script>
+
 <section id={id}>
   <div class="section-inner">
     {title && <h2>{title}</h2>}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -137,8 +137,8 @@ img {
 @supports (animation-timeline: view()) {
   section[id] {
     animation:
-      section-enter auto ease both,
-      section-exit auto ease both;
+      section-enter auto ease forwards,
+      section-exit auto ease backwards;
     animation-timeline: view(), view();
     animation-range: entry, exit;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,3 +110,40 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+/* Scroll-reveal animation */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(2rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+section[id] {
+  opacity: 0;
+  transform: translateY(2rem);
+}
+
+section[id].revealed {
+  animation: fade-in-up 0.6s ease forwards;
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  section[id] {
+    opacity: 1;
+    transform: none;
+  }
+
+  section[id].revealed {
+    animation: none;
+  }
+
+  .nav-menu {
+    transition: none;
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -123,7 +123,7 @@ img {
   }
 }
 
-section[id] {
+html.js-enabled section[id] {
   opacity: 0;
   transform: translateY(2rem);
 }
@@ -134,6 +134,10 @@ section[id].revealed {
 
 /* Respect reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
   section[id] {
     opacity: 1;
     transform: none;
@@ -141,9 +145,5 @@ section[id].revealed {
 
   section[id].revealed {
     animation: none;
-  }
-
-  .nav-menu {
-    transition: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,29 +112,25 @@ img {
 }
 
 /* Scroll-driven section reveal */
-@keyframes section-reveal {
-  0% {
+@keyframes section-enter {
+  from {
     opacity: 0;
     transform: translateY(2rem) translateX(2rem);
   }
-  50% {
+  to {
     opacity: 1;
     transform: translateY(0) translateX(0);
-  }
-  65% {
-    opacity: 1;
-    transform: translateY(0) translateX(0);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-2rem) translateX(2rem);
   }
 }
 
-@supports (animation-timeline: view()) {
-  section[id] {
-    animation: section-reveal auto ease both;
-    animation-timeline: view();
+@keyframes section-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0) translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-2rem) translateX(2rem);
   }
 }
 
@@ -142,9 +138,5 @@ img {
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
-  }
-
-  section[id] {
-    animation: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,29 +112,35 @@ img {
 }
 
 /* Scroll-driven section reveal */
-@keyframes section-reveal {
-  0% {
+@keyframes section-enter {
+  from {
     opacity: 0;
-    transform: translateY(2rem) translateX(1rem);
+    transform: translateY(2rem) translateX(2rem);
   }
-  50% {
+  to {
     opacity: 1;
     transform: translateY(0) translateX(0);
   }
-  65% {
+}
+
+@keyframes section-exit {
+  from {
     opacity: 1;
     transform: translateY(0) translateX(0);
   }
-  100% {
+  to {
     opacity: 0;
-    transform: translateY(-2rem) translateX(1rem);
+    transform: translateY(-2rem) translateX(2rem);
   }
 }
 
 @supports (animation-timeline: view()) {
   section[id] {
-    animation: section-reveal auto ease both;
-    animation-timeline: view();
+    animation:
+      section-enter auto ease both,
+      section-exit auto ease both;
+    animation-timeline: view(), view();
+    animation-range: entry, exit;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,25 +111,31 @@ img {
   height: auto;
 }
 
-/* Scroll-reveal animation */
-@keyframes fade-in-up {
-  from {
+/* Scroll-driven section reveal */
+@keyframes section-reveal {
+  0% {
     opacity: 0;
     transform: translateY(2rem);
   }
-  to {
+  25% {
     opacity: 1;
     transform: translateY(0);
   }
+  75% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-2rem);
+  }
 }
 
-html.js-enabled section[id] {
-  opacity: 0;
-  transform: translateY(2rem);
-}
-
-section[id].revealed {
-  animation: fade-in-up 0.6s ease forwards;
+@supports (animation-timeline: view()) {
+  section[id] {
+    animation: section-reveal auto ease both;
+    animation-timeline: view();
+  }
 }
 
 /* Respect reduced-motion preference */
@@ -139,11 +145,6 @@ section[id].revealed {
   }
 
   section[id] {
-    opacity: 1;
-    transform: none;
-  }
-
-  section[id].revealed {
     animation: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -123,14 +123,11 @@ img {
   }
 }
 
-@keyframes section-exit {
-  from {
-    opacity: 1;
-    transform: translateY(0) translateX(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(-2rem) translateX(2rem);
+@supports (animation-timeline: view()) {
+  .section-inner {
+    animation: section-enter auto ease forwards;
+    animation-timeline: view();
+    animation-range: cover 0% cover 500px;
   }
 }
 
@@ -138,5 +135,9 @@ img {
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+
+  .section-inner {
+    animation: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,11 +117,11 @@ img {
     opacity: 0;
     transform: translateY(2rem);
   }
-  25% {
+  10% {
     opacity: 1;
     transform: translateY(0);
   }
-  75% {
+  90% {
     opacity: 1;
     transform: translateY(0);
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -115,19 +115,19 @@ img {
 @keyframes section-reveal {
   0% {
     opacity: 0;
-    transform: translateY(2rem);
+    transform: translateY(2rem) translateX(1rem);
   }
-  10% {
+  50% {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) translateX(0);
   }
-  90% {
+  65% {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) translateX(0);
   }
   100% {
     opacity: 0;
-    transform: translateY(-2rem);
+    transform: translateY(-2rem) translateX(1rem);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,23 +112,20 @@ img {
 }
 
 /* Scroll-driven section reveal */
-@keyframes section-enter {
-  from {
+@keyframes section-reveal {
+  0% {
     opacity: 0;
     transform: translateY(2rem) translateX(2rem);
   }
-  to {
+  50% {
     opacity: 1;
     transform: translateY(0) translateX(0);
   }
-}
-
-@keyframes section-exit {
-  from {
+  65% {
     opacity: 1;
     transform: translateY(0) translateX(0);
   }
-  to {
+  100% {
     opacity: 0;
     transform: translateY(-2rem) translateX(2rem);
   }
@@ -136,11 +133,8 @@ img {
 
 @supports (animation-timeline: view()) {
   section[id] {
-    animation:
-      section-enter auto ease forwards,
-      section-exit auto ease backwards;
-    animation-timeline: view(), view();
-    animation-range: entry, exit;
+    animation: section-reveal auto ease both;
+    animation-timeline: view();
   }
 }
 


### PR DESCRIPTION
## PR6: Polish — Final PR in 6-PR portfolio modernization

### Changes
- **Scroll-driven section reveal**: Pure CSS entry animation on `.section-inner` using `animation-timeline: view()` with a fixed `cover 0% cover 500px` range — consistent 500px scroll distance for all sections regardless of height
- **prefers-reduced-motion support**: Disables scroll animations + nav transitions for users who prefer reduced motion
- **Image optimization verified**: All images use Astro `<Image />` with explicit width/height

### Key insight
Using **pixel values** in `animation-range` (rather than percentages) provides consistent animation behavior across all section sizes. Inspired by https://www.joshwcomeau.com/animation/scroll-driven-animations/

### Files changed
- `src/styles/global.css` — keyframes, scroll-driven animation with fixed pixel range, reduced-motion
- `src/layouts/Section.astro` — section structure (animation moved to global CSS)

### Testing
- ✅ All 3 Playwright smoke tests pass
- ✅ `bun run ci` passes (fmt, lint, check, tsc, build)
- ✅ Bundle size: 2.84 kB brotlied (within 6 kB limit)